### PR TITLE
Support ID5's storage.refreshInSeconds with the refreshId() implementation

### DIFF
--- a/modules/id5IdSystem.js
+++ b/modules/id5IdSystem.js
@@ -23,7 +23,7 @@ function fetchId(configParams, consentData, cachedIdObj) {
   const url = {
     protocol: ID5_PROTOCOL,
     hostname: ID5_HOSTNAME,
-    pathname: `${ID5_PATH}/${config.partner}.json`
+    pathname: `${ID5_PATH}/${configParams.partner}.json`
   };
 
   const storedUserId = this.decode(cachedIdObj);

--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -340,7 +340,7 @@ function initSubmodules(submodules, consentData) {
         const refreshInSeconds = submodule.config.storage.refreshInSeconds;
         if (utils.isFn(submodule.submodule.refreshId)) {
           let shouldRefresh = true;
-          if (utils.isNumber(refreshInSeconds)) {
+          if (utils.isNumber(refreshInSeconds) && refreshInSeconds > 0) {
             const storedDate = new Date(getStoredValue(submodule.config.storage, 'last'));
             shouldRefresh = (storedDate && (Date.now() - storedDate.getTime() > refreshInSeconds * 1000));
           }

--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -342,7 +342,9 @@ function initSubmodules(submodules, consentData) {
           let shouldRefresh = true;
           if (utils.isNumber(refreshInSeconds) && refreshInSeconds > 0) {
             const storedDate = new Date(getStoredValue(submodule.config.storage, 'last'));
-            shouldRefresh = (storedDate && (Date.now() - storedDate.getTime() > refreshInSeconds * 1000));
+            if (!storedDate || (Date.now() - storedDate.getTime() <= refreshInSeconds * 1000)) {
+              shouldRefresh = false;
+            }
           }
           if (shouldRefresh) {
             const refreshIdResult = submodule.submodule.refreshId(submodule.config.params, consentData, storedId);

--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -351,18 +351,18 @@ function initSubmodules(submodules, consentData) {
             }
           }
         }
-        if (utils.isNumber(refreshInSeconds) && ! utils.isFn(submodule.submodule.refreshId)) {
+        if (utils.isNumber(refreshInSeconds) && !utils.isFn(submodule.submodule.refreshId)) {
           utils.logWarn(`${MODULE_NAME} - storage.refreshInSeconds provided but userId system missing refreshId() implementation`);
         }
-      }
-
-      const getIdResult = submodule.submodule.getId(submodule.config.params, consentData);
-
-      if (utils.isFn(getIdResult)) {
-        submodule.callback = getIdResult;
       } else {
-        setStoredValue(submodule.config.storage, getIdResult, submodule.config.storage.expires);
-        submodule.idObj = submodule.submodule.decode(getIdResult);
+        const getIdResult = submodule.submodule.getId(submodule.config.params, consentData);
+
+        if (utils.isFn(getIdResult)) {
+          submodule.callback = getIdResult;
+        } else {
+          setStoredValue(submodule.config.storage, getIdResult, submodule.config.storage.expires);
+          submodule.idObj = submodule.submodule.decode(getIdResult);
+        }
       }
     } else if (submodule.config.value) {
       // cache decoded value (this is copied to every adUnit bid)
@@ -372,7 +372,7 @@ function initSubmodules(submodules, consentData) {
       if (typeof result === 'function') {
         submodule.callback = result;
       } else {
-        submodule.idObj = submodule.submodule.decode();
+        submodule.idObj = submodule.submodule.decode(result);
       }
     }
     carry.push(submodule);

--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -352,7 +352,7 @@ function initSubmodules(submodules, consentData) {
           }
         }
         if (utils.isNumber(refreshInSeconds) && !utils.isFn(submodule.submodule.refreshId)) {
-          utils.logWarn(`${MODULE_NAME} - storage.refreshInSeconds provided but userId system missing refreshId() implementation`);
+          utils.logWarn(`${submodule.submodule.name} - storage.refreshInSeconds provided but userId system missing refreshId() implementation`);
         }
       } else {
         const getIdResult = submodule.submodule.getId(submodule.config.params, consentData);

--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -333,41 +333,42 @@ function initSubmodules(submodules, consentData) {
       if (storedId) {
         // cache decoded value (this is copied to every adUnit bid)
         submodule.idObj = submodule.submodule.decode(storedId);
-      }
-      let refreshNeeded = false;
-      if (typeof submodule.config.storage.refreshInSeconds === 'number') {
-        const storedDate = new Date(getStoredValue(submodule.config.storage, 'last'));
-        refreshNeeded = storedDate && (Date.now() - storedDate.getTime() > submodule.config.storage.refreshInSeconds * 1000);
-      }
-      if (!storedId || refreshNeeded) {
-        // getId will return user id data or a function that will load the data
-        const getIdResult = submodule.submodule.getId(submodule.config.params, consentData, storedId);
 
-        // If the getId result has a type of function, it is asynchronous and cannot be called until later
-        if (typeof getIdResult === 'function') {
-          submodule.callback = getIdResult;
-        } else if (getIdResult) {
-          // A getId result that is not a function is assumed to be valid user id data, which should be saved to users local storage or cookies
-          setStoredValue(submodule.config.storage, getIdResult);
-          // cache decoded value (this is copied to every adUnit bid)
-          submodule.idObj = submodule.submodule.decode(getIdResult);
+        // Refresh functionality
+        // if an idSystem defines refreshId() - always call it
+        // if storage.refreshInSeconds also is defined then only call refreshId when the age of the stored value > refeshInSeconds
+        const refreshInSeconds = submodule.config.storage.refreshInSeconds;
+        if (utils.isFn(submodule.submodule.refreshId)) {
+          let shouldRefresh = true;
+          if (utils.isNumber(refreshInSeconds)) {
+            const storedDate = new Date(getStoredValue(submodule.config.storage, 'last'));
+            shouldRefresh = (storedDate && (Date.now() - storedDate.getTime() > refreshInSeconds * 1000));
+          }
+          if (shouldRefresh) {
+            const refreshIdResult = submodule.submodule.refreshId(submodule.config.params, consentData, storedId);
+            if (utils.isFn(refreshIdResult)) {
+              submodule.callback = refreshIdResult;
+            }
+          }
+        }
+        if (utils.isNumber(refreshInSeconds) && ! utils.isFn(submodule.submodule.refreshId)) {
+          utils.logWarn(`${MODULE_NAME} - storage.refreshInSeconds provided but userId system missing refreshId() implementation`);
         }
       }
 
-      if (utils.isFn(submodule.submodule.refreshId)) {
-        // if defined, refreshId will return a function that will load an updated id to be stored for subsequent use
-        const refreshIdResult = submodule.submodule.refreshId(submodule.config.params, consentData, storedId);
+      const getIdResult = submodule.submodule.getId(submodule.config.params, consentData);
 
-        // a function to be called later is expected, otherwise ignore
-        if (utils.isFn(refreshIdResult)) {
-          submodule.callback = refreshIdResult;
-        }
+      if (utils.isFn(getIdResult)) {
+        submodule.callback = getIdResult;
+      } else {
+        setStoredValue(submodule.config.storage, getIdResult, submodule.config.storage.expires);
+        submodule.idObj = submodule.submodule.decode(getIdResult);
       }
     } else if (submodule.config.value) {
       // cache decoded value (this is copied to every adUnit bid)
       submodule.idObj = submodule.config.value;
     } else {
-      const result = submodule.submodule.getId(submodule.config.params, consentData, undefined);
+      const result = submodule.submodule.getId(submodule.config.params, consentData);
       if (typeof result === 'function') {
         submodule.callback = result;
       } else {


### PR DESCRIPTION
This update's ID5's ID system to use refreshId if the storage.refreshInSeconds value is set.

There is a subtle change in behavior that needs to be run by ID5:
- before: if storage.refreshInSeconds was not set then the stored ID was never refreshed
- now: if storage.refreshInSeconds is not set then refreshId() is called on each load