### PR TITLE
Add unit coverage for parrableIdSystem getId callback

### DIFF
--- a/test/spec/modules/parrableIdSystem_spec.js
+++ b/test/spec/modules/parrableIdSystem_spec.js
@@ -1,15 +1,19 @@
 import { expect } from 'chai';
-import {config} from 'src/config.js';
+import { config } from 'src/config.js';
 import * as utils from 'src/utils.js';
 import { init, requestBidsHook, setSubmoduleRegistry } from 'modules/userId/index.js';
 import { parrableIdSubmodule } from 'modules/parrableIdSystem.js';
 import { newStorageManager } from 'src/storageManager.js';
+import { getRefererInfo } from 'src/refererDetection.js';
+
+import { server } from 'test/mocks/xhr';
 
 const storage = newStorageManager();
 
 const EXPIRED_COOKIE_DATE = 'Thu, 01 Jan 1970 00:00:01 GMT';
 const P_COOKIE_NAME = '_parrable_eid';
-const P_COOKIE_VALUE = '01.1563917337.test-eid';
+const P_COOKIE_EID = '01.1563917337.test-eid';
+const P_XHR_EID = '01.1588030911.test-new-eid'
 const P_CONFIG_MOCK = {
   name: 'parrableId',
   params: {
@@ -31,6 +35,7 @@ describe('Parrable ID System', function() {
       }
     }
   }
+
   function getAdUnitMock(code = 'adUnit-code') {
     return {
       code,
@@ -46,33 +51,76 @@ describe('Parrable ID System', function() {
     };
   }
 
+  describe('parrableIdSystem.getId()', function() {
+    let submoduleCallback;
+    let callbackSpy = sinon.spy();
+
+    beforeEach(function() {
+      submoduleCallback = parrableIdSubmodule.getId(
+        P_CONFIG_MOCK.params,
+        null,
+        P_COOKIE_EID
+      ).callback;
+      callbackSpy.reset();
+    });
+
+    it('returns a callback used to refresh the ID', function() {
+      expect(submoduleCallback).to.be.a('function');
+    });
+
+    it('invoked callback creates an xhr request to Parrable with id and telemetry', function() {
+      submoduleCallback(callbackSpy);
+
+      let request = server.requests[0];
+      let queryParams = utils.parseQS(request.url.split('?')[1]);
+      let data = JSON.parse(atob(queryParams.data));
+
+      expect(request.url).to.contain('h.parrable.com/prebid');
+      expect(data).to.deep.equal({
+        eid: P_COOKIE_EID,
+        trackers: P_CONFIG_MOCK.params.partner.split(','),
+        url: getRefererInfo().referer
+      });
+    });
+
+    it('callback responds with updated eid from Parrable backend', function() {
+      submoduleCallback(callbackSpy);
+      server.requests[0].respond(200,
+        { 'Content-Type': 'text/plain' },
+        JSON.stringify({ eid: P_XHR_EID })
+      );
+      expect(callbackSpy.calledWith(P_XHR_EID)).to.be.true;
+    });
+  });
+
   describe('Parrable ID in Bid Request', function() {
     let adUnits;
 
     beforeEach(function() {
       adUnits = [getAdUnitMock()];
-    });
-
-    it('should append parrableid to bid request', function(done) {
       // simulate existing browser local storage values
       storage.setCookie(
         P_COOKIE_NAME,
-        P_COOKIE_VALUE,
+        P_COOKIE_EID,
         (new Date(Date.now() + 5000).toUTCString())
       );
-
       setSubmoduleRegistry([parrableIdSubmodule]);
       init(config);
       config.setConfig(getConfigMock());
+    });
 
+    afterEach(function() {
+      storage.setCookie(P_COOKIE_NAME, '', EXPIRED_COOKIE_DATE);
+    });
+
+    it('provides the parrableid in the bid request', function(done) {
       requestBidsHook(function() {
         adUnits.forEach(unit => {
           unit.bids.forEach(bid => {
             expect(bid).to.have.deep.nested.property('userId.parrableid');
-            expect(bid.userId.parrableid).to.equal(P_COOKIE_VALUE);
+            expect(bid.userId.parrableid).to.equal(P_COOKIE_EID);
           });
         });
-        storage.setCookie(P_COOKIE_NAME, '', EXPIRED_COOKIE_DATE);
         done();
       }, { adUnits });
     });


### PR DESCRIPTION
To keep my changes incremental I'm opening up this discrete PR that only adds better unit testing of the parrableIdSystem module. This PR and soon to come future PRs will merge into the `parrableIdSystem/base` branch which will then be opened upstream for review.

These unit tests also cover the newly added `data.url` property.