### PR TITLE
PBID-14: Support US Privacy Framework

### DIFF
--- a/modules/parrableIdSystem.js
+++ b/modules/parrableIdSystem.js
@@ -39,9 +39,12 @@ function fetchId(configParams, currentStoredId) {
 
   const searchParams = {
     data: btoa(JSON.stringify(data)),
-    us_privacy: uspString,
     _rand: Math.random()
   };
+
+  if (uspString) {
+    searchParams.us_privacy = uspString;
+  }
 
   const options = {
     method: 'GET',

--- a/modules/parrableIdSystem.js
+++ b/modules/parrableIdSystem.js
@@ -9,6 +9,7 @@ import * as utils from '../src/utils.js'
 import { ajax } from '../src/ajax.js';
 import { submodule } from '../src/hook.js';
 import { getRefererInfo } from '../src/refererDetection.js';
+import { uspDataHandler } from '../src/adapterManager.js';
 
 const PARRABLE_URL = 'https://h.parrable.com/prebid';
 
@@ -24,10 +25,11 @@ function isValidConfig(configParams) {
   return true;
 }
 
-function fetchId(configParams, consentData, currentStoredId) {
+function fetchId(configParams, currentStoredId) {
   if (!isValidConfig(configParams)) return;
 
   const refererInfo = getRefererInfo();
+  const uspString = uspDataHandler.getConsentData();
 
   const data = {
     eid: currentStoredId || null,
@@ -37,6 +39,7 @@ function fetchId(configParams, consentData, currentStoredId) {
 
   const searchParams = {
     data: btoa(JSON.stringify(data)),
+    us_privacy: uspString,
     _rand: Math.random()
   };
 
@@ -88,8 +91,8 @@ export const parrableIdSubmodule = {
    * @param {ConsentData} [consentData]
    * @returns {function(callback:function)}
    */
-  getId(configParams, consentData, currentStoredId) {
-    return fetchId(configParams, consentData, currentStoredId);
+  getId(configParams, gdprConsentData, currentStoredId) {
+    return fetchId(configParams, currentStoredId);
   }
 };
 

--- a/test/spec/modules/parrableIdSystem_spec.js
+++ b/test/spec/modules/parrableIdSystem_spec.js
@@ -81,7 +81,7 @@ describe('Parrable ID System', function() {
       let data = JSON.parse(atob(queryParams.data));
 
       expect(request.url).to.contain('h.parrable.com/prebid');
-      expect(queryParams.us_privacy).to.equal('null');
+      expect(queryParams).to.not.have.property('us_privacy');
       expect(data).to.deep.equal({
         eid: P_COOKIE_EID,
         trackers: P_CONFIG_MOCK.params.partner.split(','),


### PR DESCRIPTION
This PR uses the Prebid consentManagementUsp module to fetch the uspString data from the browser and pass it to Parrable as the standard `us_privacy` query parameter outlined in the USP spec.