### PR TITLE
PBID-39: Fill out userIdAsEids object with UID extended data (IBA and CCPA optout status)

### DIFF
--- a/modules/connectadBidAdapter.js
+++ b/modules/connectadBidAdapter.js
@@ -85,7 +85,7 @@ export const spec = {
       })
     }
 
-    if (validBidRequests[0].userId && typeof validBidRequests[0].userId === 'object' && (validBidRequests[0].userId.tdid || validBidRequests[0].userId.pubcid || validBidRequests[0].userId.lipb || validBidRequests[0].userId.id5id || validBidRequests[0].userId.parrableid)) {
+    if (validBidRequests[0].userId && typeof validBidRequests[0].userId === 'object' && (validBidRequests[0].userId.tdid || validBidRequests[0].userId.pubcid || validBidRequests[0].userId.lipb || validBidRequests[0].userId.id5id || validBidRequests[0].userId.parrableId)) {
       utils.deepSetValue(data, 'user.ext.eids', []);
 
       if (validBidRequests[0].userId.tdid) {
@@ -118,11 +118,11 @@ export const spec = {
         });
       }
 
-      if (validBidRequests[0].userId.parrableid) {
+      if (validBidRequests[0].userId.parrableId) {
         data.user.ext.eids.push({
           source: 'parrable.com',
           uids: [{
-            id: validBidRequests[0].userId.parrableid,
+            id: validBidRequests[0].userId.parrableId.eid,
           }]
         });
       }

--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -16,7 +16,7 @@ export const USER_ID_CODE_TO_QUERY_ARG = {
   idl_env: 'lre', // LiveRamp IdentityLink
   lipb: 'lipbid', // LiveIntent ID
   netId: 'netid', // netID
-  parrableId: 'parrableId', // Parrable ID
+  parrableId: 'parrableid', // Parrable ID
   pubcid: 'pubcid', // PubCommon ID
   tdid: 'ttduuid', // The Trade Desk Unified ID
 };

--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -16,7 +16,7 @@ export const USER_ID_CODE_TO_QUERY_ARG = {
   idl_env: 'lre', // LiveRamp IdentityLink
   lipb: 'lipbid', // LiveIntent ID
   netId: 'netid', // netID
-  parrableid: 'parrableid', // Parrable ID
+  parrableId: 'parrableId', // Parrable ID
   pubcid: 'pubcid', // PubCommon ID
   tdid: 'ttduuid', // The Trade Desk Unified ID
 };

--- a/modules/ozoneBidAdapter.js
+++ b/modules/ozoneBidAdapter.js
@@ -442,7 +442,7 @@ export const spec = {
    */
   findAllUserIds(bidRequest) {
     var ret = {};
-    let searchKeysSingle = ['pubcid', 'tdid', 'id5id', 'parrableid', 'idl_env', 'digitrustid', 'criteortus'];
+    let searchKeysSingle = ['pubcid', 'tdid', 'id5id', 'parrableId', 'idl_env', 'digitrustid', 'criteortus'];
     utils.logInfo('OZONE: debug iterating keys');
     utils.logInfo('OZONE: debug bidRequest=', bidRequest);
     if (bidRequest.hasOwnProperty('userId')) {
@@ -585,7 +585,7 @@ export const spec = {
       this.addExternalUserId(eids, utils.deepAccess(bidRequest, `userId.criteortus.${BIDDER_CODE}.userid`), 'criteortus', 1);
       this.addExternalUserId(eids, utils.deepAccess(bidRequest, `userId.idl_env`), 'liveramp.com', 1);
       this.addExternalUserId(eids, utils.deepAccess(bidRequest, `userId.lipb.lipbid`), 'liveintent.com', 1);
-      this.addExternalUserId(eids, utils.deepAccess(bidRequest, `userId.parrableid`), 'parrable.com', 1);
+      this.addExternalUserId(eids, utils.deepAccess(bidRequest, `userId.parrableId.eid`), 'parrable.com', 1);
     }
     return eids;
   },

--- a/modules/parrableIdSystem.js
+++ b/modules/parrableIdSystem.js
@@ -191,7 +191,7 @@ export const parrableIdSubmodule = {
    */
   decode(parrableId) {
     if (parrableId && utils.isPlainObject(parrableId)) {
-      return { 'parrableid': parrableId.eid };
+      return { parrableId };
     }
     return undefined;
   },

--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -670,7 +670,7 @@ function _handleEids(payload, validBidRequests) {
     _addExternalUserId(eids, utils.deepAccess(bidRequest, `userId.criteoId`), 'criteo.com', 1);// replacing criteoRtus
     _addExternalUserId(eids, utils.deepAccess(bidRequest, `userId.idl_env`), 'liveramp.com', 1);
     _addExternalUserId(eids, utils.deepAccess(bidRequest, `userId.lipb.lipbid`), 'liveintent.com', 1);
-    _addExternalUserId(eids, utils.deepAccess(bidRequest, `userId.parrableid`), 'parrable.com', 1);
+    _addExternalUserId(eids, utils.deepAccess(bidRequest, `userId.parrableId.eid`), 'parrable.com', 1);
     _addExternalUserId(eids, utils.deepAccess(bidRequest, `userId.britepoolid`), 'britepool.com', 1);
     _addExternalUserId(eids, utils.deepAccess(bidRequest, `userId.netId`), 'netid.de', 1);
   }

--- a/modules/pulsepointBidAdapter.js
+++ b/modules/pulsepointBidAdapter.js
@@ -421,7 +421,7 @@ function user(bidRequest, bidderRequest) {
       addExternalUserId(ext.eids, bidRequest.userId.criteoId, 'criteo');
       addExternalUserId(ext.eids, bidRequest.userId.idl_env, 'identityLink');
       addExternalUserId(ext.eids, bidRequest.userId.id5id, 'id5-sync.com');
-      addExternalUserId(ext.eids, bidRequest.userId.parrableid, 'parrable.com');
+      addExternalUserId(ext.eids, utils.deepAccess(bidRequest, 'userId.parrableId.eid'), 'parrable.com');
       // liveintent
       if (bidRequest.userId.lipb && bidRequest.userId.lipb.lipbid) {
         addExternalUserId(ext.eids, bidRequest.userId.lipb.lipbid, 'liveintent.com');

--- a/modules/userId/eids.js
+++ b/modules/userId/eids.js
@@ -33,7 +33,15 @@ const USER_IDS_CONFIG = {
     source: 'parrable.com',
     atype: 1,
     getValue: function(parrableId) {
-      return parrableId.eid;
+      if (parrableId.eid) {
+        return parrableId.eid;
+      }
+      if (parrableId.ccpaOptout) {
+        // If the EID was suppressed due to a non consenting ccpa optout then
+        // we still wish to provide this as a reason to the adapters
+        return '';
+      }
+      return null;
     },
     getUidExt: function(parrableId) {
       const extendedData = utils.pick(parrableId, [

--- a/modules/userId/eids.js
+++ b/modules/userId/eids.js
@@ -29,9 +29,12 @@ const USER_IDS_CONFIG = {
   },
 
   // parrableId
-  'parrableid': {
+  'parrableId': {
     source: 'parrable.com',
-    atype: 1
+    atype: 1,
+    getValue: function(parrableId) {
+      return parrableId.eid;
+    }
   },
 
   // identityLink

--- a/modules/userId/eids.js
+++ b/modules/userId/eids.js
@@ -34,6 +34,15 @@ const USER_IDS_CONFIG = {
     atype: 1,
     getValue: function(parrableId) {
       return parrableId.eid;
+    },
+    getUidExt: function(parrableId) {
+      const extendedData = utils.pick(parrableId, [
+        'ibaOptout',
+        'ccpaOptout'
+      ]);
+      if (Object.keys(extendedData).length) {
+        return extendedData;
+      }
     }
   },
 

--- a/test/spec/modules/eids_spec.js
+++ b/test/spec/modules/eids_spec.js
@@ -43,7 +43,9 @@ describe('eids array generation for known sub-modules', function() {
 
   it('parrableId', function() {
     const userId = {
-      parrableid: 'some-random-id-value'
+      parrableId: {
+        eid: 'some-random-id-value'
+      }
     };
     const newEids = createEidsArray(userId);
     expect(newEids.length).to.equal(1);

--- a/test/spec/modules/openxBidAdapter_spec.js
+++ b/test/spec/modules/openxBidAdapter_spec.js
@@ -1034,7 +1034,7 @@ describe('OpenxAdapter', function () {
         idl_env: '1111-idl_env',
         lipb: {lipbid: '1111-lipb'},
         netId: 'fH5A3n2O8_CZZyPoJVD-eabc6ECb7jhxCicsds7qSg',
-        parrableid: 'eidVersion.encryptionKeyReference.encryptedValue',
+        parrableId: { eid: 'eidVersion.encryptionKeyReference.encryptedValue' },
         pubcid: '1111-pubcid',
         tdid: '1111-tdid',
       };

--- a/test/spec/modules/ozoneBidAdapter_spec.js
+++ b/test/spec/modules/ozoneBidAdapter_spec.js
@@ -37,7 +37,7 @@ var validBidRequestsWithUserIdData = [
     params: { publisherId: '9876abcd12-3', customData: [{'settings': {}, 'targeting': {'gender': 'bart', 'age': 'low'}}], lotameData: {'Profile': {'tpid': 'c8ef27a0d4ba771a81159f0d2e792db4', 'Audiences': {'Audience': [{'id': '99999', 'abbr': 'sports'}, {'id': '88888', 'abbr': 'movie'}, {'id': '77777', 'abbr': 'blogger'}], 'ThirdPartyAudience': [{'id': '123', 'name': 'Automobiles'}, {'id': '456', 'name': 'Ages: 30-39'}]}}}, placementId: '1310000099', siteId: '1234567890', id: 'fea37168-78f1-4a23-a40e-88437a99377e', auctionId: '27dcb421-95c6-4024-a624-3c03816c5f99', imp: [ { id: '2899ec066a91ff8', tagid: 'undefined', secure: 1, banner: { format: [{ w: 300, h: 250 }, { w: 300, h: 600 }], h: 250, topframe: 1, w: 300 } } ] },
     sizes: [[300, 250], [300, 600]],
     transactionId: '2e63c0ed-b10c-4008-aed5-84582cecfe87',
-    userId: {'pubcid': '12345678', 'id5id': 'ID5-someId', 'criteortus': {'ozone': {'userid': 'critId123'}}, 'idl_env': 'liverampId', 'lipb': {'lipbid': 'lipbidId123'}, 'parrableid': 'parrableid123'}
+    userId: {'pubcid': '12345678', 'id5id': 'ID5-someId', 'criteortus': {'ozone': {'userid': 'critId123'}}, 'idl_env': 'liverampId', 'lipb': {'lipbid': 'lipbidId123'}, 'parrableId': {eid: 'parrableid123'}}
   }
 ];
 var validBidRequestsMinimal = [
@@ -1039,7 +1039,7 @@ describe('ozone Adapter', function () {
         'id5id': '2222',
         'idl_env': '3333',
         'lipb': {'lipbid': '4444'},
-        'parrableid': 'eidVersion.encryptionKeyReference.encryptedValue',
+        'parrableId': {eid: 'eidVersion.encryptionKeyReference.encryptedValue'},
         'pubcid': '5555',
         'tdid': '6666'
       };
@@ -1059,7 +1059,7 @@ describe('ozone Adapter', function () {
         'id5id': '2222',
         'idl_env': '3333',
         'lipb': {'lipbid': '4444'},
-        'parrableid': 'eidVersion.encryptionKeyReference.encryptedValue',
+        'parrableId': {eid: 'eidVersion.encryptionKeyReference.encryptedValue'},
         // 'pubcid': '5555', // remove pubcid from here to emulate the OLD module & cause the failover code to kick in
         'tdid': '6666'
       };

--- a/test/spec/modules/parrableIdSystem_spec.js
+++ b/test/spec/modules/parrableIdSystem_spec.js
@@ -171,11 +171,11 @@ describe('Parrable ID System', function() {
       let eid = '01.123.4567890';
       let parrableId = {
         eid,
-        ccpaOptout: true
+        ibaOptout: true
       };
 
       expect(parrableIdSubmodule.decode(parrableId)).to.deep.equal({
-        parrableid: eid
+        parrableId
       });
     });
   });
@@ -199,8 +199,8 @@ describe('Parrable ID System', function() {
       requestBidsHook(function() {
         adUnits.forEach(unit => {
           unit.bids.forEach(bid => {
-            expect(bid).to.have.deep.nested.property('userId.parrableid');
-            expect(bid.userId.parrableid).to.equal(P_COOKIE_EID);
+            expect(bid).to.have.deep.nested.property('userId.parrableId');
+            expect(bid.userId.parrableId.eid).to.equal(P_COOKIE_EID);
           });
         });
         done();

--- a/test/spec/modules/parrableIdSystem_spec.js
+++ b/test/spec/modules/parrableIdSystem_spec.js
@@ -221,7 +221,7 @@ describe('Parrable ID System', function() {
             expect(bid).to.have.deep.nested.property('userId.parrableId');
             expect(bid.userId.parrableId.eid).to.equal(P_COOKIE_EID);
             expect(bid.userId.parrableId.ibaOptout).to.equal(true);
-            const [ parrableIdAsEid ] = bid.userIdAsEids.filter(e => e.source == 'parrable.com');
+            const parrableIdAsEid = bid.userIdAsEids.find(e => e.source == 'parrable.com');
             expect(parrableIdAsEid).to.deep.equal({
               source: 'parrable.com',
               uids: [{

--- a/test/spec/modules/parrableIdSystem_spec.js
+++ b/test/spec/modules/parrableIdSystem_spec.js
@@ -185,7 +185,7 @@ describe('Parrable ID System', function() {
 
     beforeEach(function() {
       adUnits = [getAdUnitMock()];
-      writeParrableCookie({ eid: P_COOKIE_EID });
+      writeParrableCookie({ eid: P_COOKIE_EID, ibaOptout: true });
       setSubmoduleRegistry([parrableIdSubmodule]);
       init(config);
       config.setConfig(getConfigMock());
@@ -201,6 +201,18 @@ describe('Parrable ID System', function() {
           unit.bids.forEach(bid => {
             expect(bid).to.have.deep.nested.property('userId.parrableId');
             expect(bid.userId.parrableId.eid).to.equal(P_COOKIE_EID);
+            expect(bid.userId.parrableId.ibaOptout).to.equal(true);
+            const [ parrableIdAsEid ] = bid.userIdAsEids.filter(e => e.source == 'parrable.com');
+            expect(parrableIdAsEid).to.deep.equal({
+              source: 'parrable.com',
+              uids: [{
+                id: P_COOKIE_EID,
+                atype: 1,
+                ext: {
+                  ibaOptout: true
+                }
+              }]
+            });
           });
         });
         done();

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -1102,7 +1102,7 @@ describe('S2S Adapter', function () {
         criteoId: '44VmRDeUE3ZGJ5MzRkRVJHU3BIUlJ6TlFPQUFU',
         tdid: 'abc123',
         pubcid: '1234',
-        parrableid: '01.1563917337.test-eid',
+        parrableId: { eid: '01.1563917337.test-eid' },
         lipb: {
           lipbid: 'li-xyz',
           segments: ['segA', 'segB']

--- a/test/spec/modules/pubmaticBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticBidAdapter_spec.js
@@ -1861,7 +1861,7 @@ describe('PubMatic adapter', function () {
         describe('Parrable Id', function() {
           it('send the Parrable id if it is present', function() {
             bidRequests[0].userId = {};
-            bidRequests[0].userId.parrableid = 'parrable-user-id';
+            bidRequests[0].userId.parrableId = { eid: 'parrable-user-id' };
             let request = spec.buildRequests(bidRequests, {});
             let data = JSON.parse(request.data);
             expect(data.user.eids).to.deep.equal([{
@@ -1873,21 +1873,21 @@ describe('PubMatic adapter', function () {
             }]);
           });
 
-          it('do not pass if not string', function() {
+          it('do not pass if not object with eid key', function() {
             bidRequests[0].userId = {};
-            bidRequests[0].userId.parrableid = 1;
+            bidRequests[0].userId.parrableId = 1;
             let request = spec.buildRequests(bidRequests, {});
             let data = JSON.parse(request.data);
             expect(data.user.eids).to.equal(undefined);
-            bidRequests[0].userId.parrableid = [];
+            bidRequests[0].userId.parrableId = [];
             request = spec.buildRequests(bidRequests, {});
             data = JSON.parse(request.data);
             expect(data.user.eids).to.equal(undefined);
-            bidRequests[0].userId.parrableid = null;
+            bidRequests[0].userId.parrableId = null;
             request = spec.buildRequests(bidRequests, {});
             data = JSON.parse(request.data);
             expect(data.user.eids).to.equal(undefined);
-            bidRequests[0].userId.parrableid = {};
+            bidRequests[0].userId.parrableId = {};
             request = spec.buildRequests(bidRequests, {});
             data = JSON.parse(request.data);
             expect(data.user.eids).to.equal(undefined);

--- a/test/spec/modules/pulsepointBidAdapter_spec.js
+++ b/test/spec/modules/pulsepointBidAdapter_spec.js
@@ -631,7 +631,7 @@ describe('PulsePoint Adapter Tests', function () {
       criteoId: 'criteo_id234',
       idl_env: 'idl_id123',
       id5id: 'id5id_234',
-      parrableid: 'parrable_id234',
+      parrableId: { eid: 'parrable_id234' },
       lipb: {
         lipbid: 'liveintent_id123'
       }


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change

This change enables adapters that consume the `userIdAsEids` object to access Parrable's optout states (CCPA and IBA) provided as part of the ORTB UIDs extended data field.
